### PR TITLE
Correct bug when passing non-string query params.

### DIFF
--- a/src/groovy/com/budjb/requestbuilder/RequestBuilder.groovy
+++ b/src/groovy/com/budjb/requestbuilder/RequestBuilder.groovy
@@ -506,7 +506,7 @@ class RequestBuilder {
 
         // Set any query params
         query.each { param, value ->
-            resource = resource.queryParam(param, value)
+            resource = resource.queryParam(param as String, value as String)
         }
 
         // Get the builder


### PR DESCRIPTION
When passing anything other than a String, will stacktrace. For
instance:

``` groovy
new RequestBuilder().build {
    uri = "127.0.0.1:8080/sample.com"
    query = [
        myQuery: true
    ]
}
```

Will break because true is not a String.
